### PR TITLE
Change `note` to `comment`

### DIFF
--- a/Support/bin/add
+++ b/Support/bin/add
@@ -46,5 +46,5 @@ else
   subject = CGI::escape(subject.gsub('%', '%25')).gsub('+', '%20') 
   note = CGI::escape(note.gsub('%', '%25')).gsub('+', '%20')
 
-  system("open", "todoist://addtask?content=#{subject}&note=#{note}&date=today")
+  system("open", "todoist://addtask?content=#{subject}&comment=#{note}&date=today")
 end


### PR DESCRIPTION
Looking into why the Todoist "add with summary" command doesn't work, I came across [a message on the mailing list](https://lists.freron.com/mailmate/2019-June/011588.html). I found that the following URL scheme does work in the terminal `open "todoist://addtask?content=test&comment=testnote&date=today"` but when I tried to modify MailMate's Todoist bundle on my machine with the proposed change, it still didn't work. 

I couldn't find this documented in the API, but this would allow us to get rid of the `if !note.empty?` statement, correct? At the moment the web API call doesn't seem to work either